### PR TITLE
Add AsyncAdapter

### DIFF
--- a/async_adapter.go
+++ b/async_adapter.go
@@ -1,0 +1,261 @@
+// Copyright 2023 Josh Deprez
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yarn
+
+import (
+	"errors"
+	"fmt"
+	"sync/atomic"
+)
+
+// ErrAlreadyStopped is returned when the AsyncAdapter cannot
+// stop the virtual machine, because it is already stopped.
+const ErrAlreadyStopped = virtualMachineError("VM already stopped or stopping")
+
+var _ DialogueHandler = &AsyncAdapter{}
+
+// VMState enumerates the different states that AsyncAdapter can be in.
+type VMState int32
+
+const (
+	// No event has been delivered (since the last call to Go / GoWithOption);
+	// the VM is executing.
+	VMStateRunning = iota
+
+	// An event other than Options was delivered, and VM execution is blocked.
+	VMStatePaused
+
+	// Options event was delivered, and VM execution is blocked.
+	VMStatePausedOptions
+
+	// Execution has not begun, or has ended (e.g. by calling Abort, or any
+	// other error).
+	VMStateStopped
+)
+
+func (s VMState) String() string {
+	switch s {
+	case VMStateRunning:
+		return "Running"
+	case VMStatePaused:
+		return "Paused"
+	case VMStatePausedOptions:
+		return "PausedOptions"
+	case VMStateStopped:
+		return "Stopped"
+	}
+	return fmt.Sprintf("(invalid VMState %d)", s)
+}
+
+// VMStateMismatchErr is returned when AsyncAdapter is told to do something (either
+// by the user calling Go, GoWithChoice, or Abort, or the VM calling a
+// DialogueHandler method) but this requires AsyncAdapter to be in a different state
+// than the state it is in.
+type VMStateMismatchErr struct {
+	// The VM was in state Got, but we wanted it to be in state Want in order
+	// to change it to state Next.
+	Got, Want, Next VMState
+}
+
+func (e VMStateMismatchErr) Error() string {
+	return fmt.Sprintf("VM is %v, so cannot transition from %v to %v", e.Got, e.Want, e.Next)
+}
+
+// AsyncAdapter is a DialogueHandler that exposes an interface that is similar
+// to the mainline YarnSpinner VM dialogue handler. Instead of manually blocking
+// inside the DialogueHandler Line, Options, and Command callbacks, AsyncAdapter
+// does this for you, until you call Go, GoWithChoice, or Abort (as
+// appropriate).
+type AsyncAdapter struct {
+	state   atomic.Int32
+	handler AsyncDialogueHandler
+	msgCh   chan asyncMsg
+}
+
+// NewAsyncAdapter returns a new AsyncAdapter.
+func NewAsyncAdapter(h AsyncDialogueHandler) *AsyncAdapter {
+	return &AsyncAdapter{
+		handler: h,
+		// The user might call Go from within their handler's Line method
+		// (or however many other ways to try to continue the VM immediately).
+		// If ch was unbuffered, calling Go would wait forever trying to send on
+		// the channel, because AsyncAdapter only receives on ch after their method
+		// returns.
+		msgCh: make(chan asyncMsg, 1),
+	}
+}
+
+// State returns the current state.
+func (a *AsyncAdapter) State() VMState {
+	return VMState(a.state.Load())
+}
+
+func (a *AsyncAdapter) stateTransition(old, new int32) error {
+	if !a.state.CompareAndSwap(old, new) {
+		// This races (between CAS and a.State, something else could switch the
+		// state around). While I try to make the error maximally useful
+		// for debugging ... YOLO?
+		return VMStateMismatchErr{
+			Got:  a.State(),
+			Want: VMState(old),
+			Next: VMState(new),
+		}
+	}
+	return nil
+}
+
+// Go will continue the VM after it has delivered any event (other than
+// Options). If the VM is not waiting for an event, an error will be returned.
+func (a *AsyncAdapter) Go() error {
+	if err := a.stateTransition(VMStatePaused, VMStateRunning); err != nil {
+		return err
+	}
+	a.msgCh <- goMsg{}
+	return nil
+}
+
+// GoWithChoice will continue the VM after it has delivered an Options event.
+// Pass
+func (a *AsyncAdapter) GoWithChoice(id int) error {
+	if err := a.stateTransition(VMStatePausedOptions, VMStateRunning); err != nil {
+		return err
+	}
+	a.msgCh <- choiceMsg{id}
+	return nil
+}
+
+// Abort stops the VM with the given error as soon as possible (either within
+// the current event, or on the next event). If a nil error is passed, Abort
+// will replace it with Stop (so that NodeComplete and DialogueComplete still
+// fire).
+func (a *AsyncAdapter) Abort(err error) error {
+	if old := a.state.Swap(VMStateStopped); old == VMStateStopped {
+		return ErrAlreadyStopped
+	}
+	if err == nil {
+		err = Stop
+	}
+	a.msgCh <- abortMsg{err}
+	return nil
+}
+
+// waitForGo waits for Go or Abort to be called.
+func (a *AsyncAdapter) waitForGo() error {
+	switch msg := (<-a.msgCh).(type) {
+	case goMsg:
+		return nil
+	case choiceMsg:
+		// This is incredibly unlikely, but I check it anyway.
+		return errors.New("AsyncAdapter.GoWithChoice called, but last event was not Options")
+	case abortMsg:
+		return msg.err
+	default:
+		return fmt.Errorf("invalid message type %T received", msg)
+	}
+}
+
+// waitForChoice waits for GoWithChoice or Abort to be called.
+func (a *AsyncAdapter) waitForChoice() (int, error) {
+	switch msg := (<-a.msgCh).(type) {
+	case goMsg:
+		// This is incredibly unlikely, but I check it anyway.
+		return -1, errors.New("AsyncAdapter.Go called, but last event was Options")
+	case choiceMsg:
+		return msg.choice, nil
+	case abortMsg:
+		return -1, msg.err
+	default:
+		return -1, fmt.Errorf("invalid message type %T received", msg)
+	}
+}
+
+// --- DialogueHandler implementation --- \\
+
+// NodeStart is called by the VM and passed through to the
+// AsyncDialogueHandler directly.
+func (a *AsyncAdapter) NodeStart(nodeName string) error {
+	return a.handler.NodeStart(nodeName)
+}
+
+// PrepareForLines is called by the VM and passed through to the
+// AsyncDialogueHandler directly.
+func (a *AsyncAdapter) PrepareForLines(lineIDs []string) error {
+	return a.handler.PrepareForLines(lineIDs)
+}
+
+// Line is called by the VM and blocks until Go or Abort is called.
+func (a *AsyncAdapter) Line(line Line) error {
+	if err := a.stateTransition(VMStateRunning, VMStatePaused); err != nil {
+		return err
+	}
+	a.handler.Line(line)
+	return a.waitForGo()
+}
+
+// Options is called by the VM and blocks until GoWithChoice or Abort is called.
+func (a *AsyncAdapter) Options(options []Option) (int, error) {
+	if err := a.stateTransition(VMStateRunning, VMStatePausedOptions); err != nil {
+		return -1, err
+	}
+	a.handler.Options(options)
+	return a.waitForChoice()
+}
+
+// Command is called by the VM and blocks until Go or Abort is called.
+func (a *AsyncAdapter) Command(command string) error {
+	if err := a.stateTransition(VMStateRunning, VMStatePaused); err != nil {
+		return err
+	}
+	a.handler.Command(command)
+	return a.waitForGo()
+}
+
+// NodeComplete is called by the VM and passed through to the
+// AsyncDialogueHandler directly.
+func (a *AsyncAdapter) NodeComplete(nodeName string) error {
+	return a.handler.NodeComplete(nodeName)
+}
+
+// DialogueComplete is called by the VM and passed through to the
+// AsyncDialogueHandler directly.
+func (a *AsyncAdapter) DialogueComplete() error {
+	return a.handler.DialogueComplete()
+}
+
+// --- AsyncAdapter messages --- \\
+
+// AsyncAdapter works by waiting on a channel. The three message types are below.
+type asyncMsg interface {
+	asyncMsgTag()
+}
+
+// Sent on the channel when Go is called.
+type goMsg struct{}
+
+func (goMsg) asyncMsgTag() {}
+
+// Sent on the channel when GoWithChoice is called.
+type choiceMsg struct {
+	choice int
+}
+
+func (choiceMsg) asyncMsgTag() {}
+
+// Sent on the channel when Abort is called.
+type abortMsg struct {
+	err error
+}
+
+func (abortMsg) asyncMsgTag() {}

--- a/async_adapter_test.go
+++ b/async_adapter_test.go
@@ -1,0 +1,418 @@
+// Copyright 2023 Josh Deprez
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yarn
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// syncAdapter converts the AsyncAdapter back into the synchronous interface.
+type syncAdapter struct {
+	dh DialogueHandler
+	aa *AsyncAdapter
+	t  *testing.T
+}
+
+func (s *syncAdapter) NodeStart(nodeName string) error {
+	return s.dh.NodeStart(nodeName)
+}
+
+func (s *syncAdapter) PrepareForLines(lineIDs []string) error {
+	return s.dh.PrepareForLines(lineIDs)
+}
+
+func (s *syncAdapter) Line(line Line) {
+	if err := s.dh.Line(line); err != nil {
+		s.t.Errorf("syncAdapter.DialogueHandler.Line(%v) = %v", line, err)
+	}
+	if err := s.aa.Go(); err != nil {
+		s.t.Errorf("syncAdapter.AsyncAdapter.Go() = %v", err)
+	}
+}
+
+func (s *syncAdapter) Options(options []Option) {
+	choice, err := s.dh.Options(options)
+	if err != nil {
+		s.t.Errorf("syncAdapter.DialogueHandler.Options(%v) = %v", options, err)
+	}
+	if err := s.aa.GoWithChoice(choice); err != nil {
+		s.t.Errorf("syncAdapter.AsyncAdapter.GoWithChoice(%d) = %v", choice, err)
+	}
+}
+
+func (s *syncAdapter) Command(command string) {
+	if err := s.dh.Command(command); err != nil {
+		s.t.Errorf("syncAdapter.DialogueHandler.Command(%v) = %v", command, err)
+	}
+	if err := s.aa.Go(); err != nil {
+		s.t.Errorf("syncAdapter.AsyncAdapter.Go() = %v", err)
+	}
+}
+
+func (s *syncAdapter) NodeComplete(nodeName string) error {
+	return s.dh.NodeComplete(nodeName)
+}
+
+func (s *syncAdapter) DialogueComplete() error {
+	return s.dh.DialogueComplete()
+}
+
+func TestAllTestPlansAsync(t *testing.T) {
+	testplans, err := filepath.Glob("testdata/*.testplan")
+	if err != nil {
+		t.Fatalf("Glob: %v", err)
+	}
+
+	for _, tpn := range testplans {
+		t.Run(tpn, func(t *testing.T) {
+			testplan, err := LoadTestPlanFile(tpn)
+			if err != nil {
+				t.Fatalf("LoadTestPlanFile(%q) = error %v", tpn, err)
+			}
+
+			// VM -> AsyncAdapter -> syncAdapter -> testplan
+			sa := &syncAdapter{
+				dh: testplan,
+				t:  t,
+			}
+			sa.aa = NewAsyncAdapter(sa)
+
+			base := strings.TrimSuffix(filepath.Base(tpn), ".testplan")
+
+			yarnc := "testdata/" + base + ".yarnc"
+			prog, st, err := LoadFiles(yarnc, "en")
+			if err != nil {
+				t.Fatalf("LoadFiles(%q, en) = error %v", yarnc, err)
+			}
+
+			vm := &VirtualMachine{
+				Program: prog,
+				Handler: sa.aa,
+				Vars:    make(MapVariableStorage),
+				FuncMap: FuncMap{
+					// Used by various
+					"assert": func(x interface{}) error {
+						t, err := ConvertToBool(x)
+						if err != nil {
+							return err
+						}
+						if !t {
+							return errors.New("assertion failed")
+						}
+						return nil
+					},
+					// Used by Functions.yarn
+					// TODO: support ints like the real Yarn Spinner
+					"add_three_operands": func(x, y, z float32) float32 {
+						return x + y + z
+					},
+					"last_value": func(x ...interface{}) (interface{}, error) {
+						if len(x) == 0 {
+							return nil, errors.New("no args")
+						}
+						return x[len(x)-1], nil
+					},
+					"dummy_number": func() float32 {
+						return 1
+					},
+					"dummy_bool": func() bool {
+						return true
+					},
+					"dummy_string": func() string {
+						return "string"
+					},
+				},
+			}
+			testplan.StringTable = st
+			if traceOutput {
+				vm.TraceLogf = t.Logf
+			}
+
+			if err := vm.Run("Start"); err != nil {
+				t.Errorf("vm.Run(Start) = %v", err)
+			}
+			if err := testplan.Complete(); err != nil {
+				t.Errorf("testplan incomplete: %v", err)
+			}
+		})
+	}
+}
+
+type decoupledEvent struct {
+	followup func(*AsyncAdapter) error
+	desc     string
+}
+
+// decoupledAsyncHandler handles each event and then stores a follow-up action
+// to run afterwards.
+type decoupledAsyncHandler struct {
+	FakeAsyncDialogueHandler
+	eventCh chan decoupledEvent
+}
+
+func (d *decoupledAsyncHandler) Line(line Line) {
+	d.eventCh <- decoupledEvent{
+		followup: (*AsyncAdapter).Go,
+		desc:     fmt.Sprintf("Line(%v)", line),
+	}
+}
+
+func (d *decoupledAsyncHandler) Options(options []Option) {
+	d.eventCh <- decoupledEvent{
+		followup: func(aa *AsyncAdapter) error {
+			return aa.GoWithChoice(options[0].ID)
+		},
+		desc: fmt.Sprintf("Options(%v)", options),
+	}
+}
+
+func (d *decoupledAsyncHandler) Command(command string) {
+	d.eventCh <- decoupledEvent{
+		followup: (*AsyncAdapter).Go,
+		desc:     fmt.Sprintf("Command(%q)", command),
+	}
+}
+
+func (d *decoupledAsyncHandler) DialogueComplete() error {
+	close(d.eventCh)
+	return nil
+}
+
+func TestAsyncAdapterWithDecoupledHandler(t *testing.T) {
+	yarnc := "testdata/Example.yarnc"
+	prog, _, err := LoadFiles(yarnc, "en")
+	if err != nil {
+		t.Fatalf("LoadFiles(%q, en) = error %v", yarnc, err)
+	}
+
+	dh := &decoupledAsyncHandler{
+		eventCh: make(chan decoupledEvent),
+	}
+	aa := NewAsyncAdapter(dh)
+
+	vm := &VirtualMachine{
+		Program: prog,
+		Handler: aa,
+		Vars:    make(MapVariableStorage),
+	}
+	if traceOutput {
+		vm.TraceLogf = t.Logf
+	}
+
+	go func() {
+		if err := vm.Run("Start"); err != nil {
+			t.Errorf("vm.Run(Start) = %v", err)
+		}
+	}()
+
+	for e := range dh.eventCh {
+		if err := e.followup(aa); err != nil {
+			t.Errorf("followup after %s: %v", e.desc, err)
+		}
+	}
+}
+
+// immediateAsyncHandler calls Go and GoWithChoice within each event.
+type immediateAsyncHandler struct {
+	FakeAsyncDialogueHandler
+	aa *AsyncAdapter
+	t  *testing.T
+}
+
+func (i *immediateAsyncHandler) Line(Line) {
+	if err := i.aa.Go(); err != nil {
+		i.t.Errorf("AsyncAdapter.Go() = %v", err)
+	}
+}
+
+func (i *immediateAsyncHandler) Options(options []Option) {
+	id := options[0].ID
+	if err := i.aa.GoWithChoice(id); err != nil {
+		i.t.Errorf("AsyncAdapter.GoWithChoice(%d) = %v", id, err)
+	}
+}
+
+func (i *immediateAsyncHandler) Command(string) {
+	if err := i.aa.Go(); err != nil {
+		i.t.Errorf("AsyncAdapter.Go() = %v", err)
+	}
+}
+
+func TestAsyncAdapterWithImmediateHandler(t *testing.T) {
+	yarnc := "testdata/Example.yarnc"
+	prog, _, err := LoadFiles(yarnc, "en")
+	if err != nil {
+		t.Fatalf("LoadFiles(%q, en) = error %v", yarnc, err)
+	}
+
+	ah := &immediateAsyncHandler{t: t}
+	aa := NewAsyncAdapter(ah)
+	ah.aa = aa
+
+	vm := &VirtualMachine{
+		Program: prog,
+		Handler: aa,
+		Vars:    make(MapVariableStorage),
+	}
+	if traceOutput {
+		vm.TraceLogf = t.Logf
+	}
+
+	if err := vm.Run("Start"); err != nil {
+		t.Errorf("vm.Run(Start) = %v", err)
+	}
+}
+
+// badAsyncHandler calls the wrong continuation methods first, then the right
+// ones.
+type badAsyncHandler struct {
+	FakeAsyncDialogueHandler
+	aa *AsyncAdapter
+	t  *testing.T
+}
+
+func (b *badAsyncHandler) Line(Line) {
+	want := VMStateMismatchErr{
+		Got:  VMStatePaused,
+		Want: VMStatePausedOptions,
+		Next: VMStateRunning,
+	}
+	if diff := cmp.Diff(b.aa.GoWithChoice(6), want); diff != "" {
+		b.t.Errorf("AsyncAdapter.GoWithChoice(6) error diff (-got +want):\n%s", diff)
+	}
+	// call Go to proceed, otherwise it hangs (it's waiting for Go, duh)
+	if err := b.aa.Go(); err != nil {
+		b.t.Errorf("AsyncAdapter.Go() = %v", err)
+	}
+}
+
+func (b *badAsyncHandler) Options(options []Option) {
+	want := VMStateMismatchErr{
+		Got:  VMStatePausedOptions,
+		Want: VMStatePaused,
+		Next: VMStateRunning,
+	}
+	if diff := cmp.Diff(b.aa.Go(), want); diff != "" {
+		b.t.Errorf("AsyncAdapter.Go() error diff (-got +want):\n%s", diff)
+	}
+	// call GoWithChoice to proceed, otherwise it hangs
+	choice := options[0].ID
+	if err := b.aa.GoWithChoice(choice); err != nil {
+		b.t.Errorf("AsyncAdapter.GoWithChoice(%d) = %v", choice, err)
+	}
+}
+
+func (b *badAsyncHandler) Command(string) {
+	want := VMStateMismatchErr{
+		Got:  VMStatePaused,
+		Want: VMStatePausedOptions,
+		Next: VMStateRunning,
+	}
+	if diff := cmp.Diff(b.aa.GoWithChoice(0), want); diff != "" {
+		b.t.Errorf("AsyncAdapter.GoWithChoice(0) error diff (-got +want):\n%s", diff)
+	}
+	// pass Go, collect $200
+	if err := b.aa.Go(); err != nil {
+		b.t.Errorf("AsyncAdapter.Go() = %v", err)
+	}
+}
+
+func TestAsyncAdapterWithBadHandler(t *testing.T) {
+	yarnc := "testdata/Example.yarnc"
+	prog, _, err := LoadFiles(yarnc, "en")
+	if err != nil {
+		t.Fatalf("LoadFiles(%q, en) = error %v", yarnc, err)
+	}
+
+	bh := &badAsyncHandler{t: t}
+	aa := NewAsyncAdapter(bh)
+	bh.aa = aa
+
+	vm := &VirtualMachine{
+		Program: prog,
+		Handler: aa,
+		Vars:    make(MapVariableStorage),
+	}
+	if traceOutput {
+		vm.TraceLogf = t.Logf
+	}
+
+	if err := vm.Run("Start"); err != nil {
+		t.Errorf("vm.Run(Start) = %v", err)
+	}
+}
+
+var errDummy = errors.New("abort! abort!")
+
+// abortAsyncHandler calls Abort within each event.
+type abortAsyncHandler struct {
+	FakeAsyncDialogueHandler
+	aa *AsyncAdapter
+	t  *testing.T
+}
+
+func (a *abortAsyncHandler) Line(Line) {
+	if err := a.aa.Abort(errDummy); err != nil {
+		a.t.Errorf("AsyncAdapter.Abort(errDummy) = %v", err)
+	}
+}
+
+func (a *abortAsyncHandler) Options(options []Option) {
+	if err := a.aa.Abort(errDummy); err != nil {
+		a.t.Errorf("AsyncAdapter.Abort(errDummy) = %v", err)
+	}
+}
+
+func (a *abortAsyncHandler) Command(string) {
+	if err := a.aa.Abort(errDummy); err != nil {
+		a.t.Errorf("AsyncAdapter.Abort(errDummy) = %v", err)
+	}
+}
+
+func TestAsyncAdapterWithAbortHandler(t *testing.T) {
+	yarnc := "testdata/Example.yarnc"
+	prog, _, err := LoadFiles(yarnc, "en")
+	if err != nil {
+		t.Fatalf("LoadFiles(%q, en) = error %v", yarnc, err)
+	}
+
+	bh := &abortAsyncHandler{t: t}
+	aa := NewAsyncAdapter(bh)
+	bh.aa = aa
+
+	vm := &VirtualMachine{
+		Program: prog,
+		Handler: aa,
+		Vars:    make(MapVariableStorage),
+	}
+	if traceOutput {
+		vm.TraceLogf = t.Logf
+	}
+
+	if err := vm.Run("Start"); !errors.Is(err, errDummy) {
+		t.Errorf("vm.Run(Start) = %v, want %v", err, errDummy)
+	}
+
+	// aborting while stopped should give an error
+	if err := aa.Abort(errDummy); !errors.Is(err, ErrAlreadyStopped) {
+		t.Errorf("aa.Abort(errDummy) = %v, want %v", err, ErrAlreadyStopped)
+	}
+}

--- a/cmd/yarnrunner.go
+++ b/cmd/yarnrunner.go
@@ -21,8 +21,7 @@
 // Quick usage from the root of the repo:
 //
 //	go run -tags example cmd/yarnrunner.go \
-//	    --program=testdata/Example.yarn.yarnc \
-//	    --strings=testdata/Example.yarn.csv
+//	    --program=testdata/Example.yarn.yarnc
 //
 // The "example" build tag is used to prevent this being installed to ~/go/bin
 // if you use the go get command. If for some reason you want to install it to
@@ -39,12 +38,11 @@ import (
 
 func main() {
 	yarncFilename := flag.String("program", "", "File name of program (e.g. Example.yarn.yarnc)")
-	csvFilename := flag.String("strings", "", "File name of string table (e.g. Example.yarn.csv)")
 	startNode := flag.String("start", "Start", "Name of the node to run")
 	langCode := flag.String("lang", "en-AU", "Language tag (BCP 47)")
 	flag.Parse()
 
-	program, stringTable, err := yarn.LoadFiles(*yarncFilename, *csvFilename, *langCode)
+	program, stringTable, err := yarn.LoadFiles(*yarncFilename, *langCode)
 	if err != nil {
 		log.Fatalf("Loading files: %v", err)
 	}

--- a/dialogue.go
+++ b/dialogue.go
@@ -72,27 +72,23 @@ type DialogueHandler interface {
 }
 
 // AsyncDialogueHandler receives events from AsyncAdapter. Unlike
-// DialogueHandler, during each even, the VM execution is paused automatically,
-// until AsyncAdapter is told to continue.
+// DialogueHandler, during each event the VM execution is paused automatically
+// until Go, GoWithChoice, or Abort is called.
 type AsyncDialogueHandler interface {
 	// NodeStart is called when a node has begun executing. It is passed the
 	// name of the node.
-	// This event does not pause the VM.
-	NodeStart(nodeName string) error
+	NodeStart(nodeName string)
 
 	// PrepareForLines is called when the dialogue system anticipates that it
 	// will deliver some lines. Note that not every line prepared may end up
 	// being run.
-	// This event does not pause the VM.
-	PrepareForLines(lineIDs []string) error
+	PrepareForLines(lineIDs []string)
 
-	// Line is called when the dialogue system runs a line of dialogue. This
-	// event pauses the VM until AsyncAdapter.Go is called.
+	// Line is called when the dialogue system runs a line of dialogue.
 	Line(line Line)
 
 	// Options is called to deliver a set of options to the game. The player
 	// should choose one of the options.
-	// This event pauses the VM.
 	Options(options []Option)
 
 	// Command is called when the dialogue system runs a command.
@@ -100,8 +96,8 @@ type AsyncDialogueHandler interface {
 
 	// NodeComplete is called when a node has completed execution. It is passed
 	// the name of the node.
-	NodeComplete(nodeName string) error
+	NodeComplete(nodeName string)
 
 	// DialogueComplete is called when the dialogue as a whole is complete.
-	DialogueComplete() error
+	DialogueComplete()
 }

--- a/dialogue.go
+++ b/dialogue.go
@@ -70,3 +70,38 @@ type DialogueHandler interface {
 	// DialogueComplete is called when the dialogue as a whole is complete.
 	DialogueComplete() error
 }
+
+// AsyncDialogueHandler receives events from AsyncAdapter. Unlike
+// DialogueHandler, during each even, the VM execution is paused automatically,
+// until AsyncAdapter is told to continue.
+type AsyncDialogueHandler interface {
+	// NodeStart is called when a node has begun executing. It is passed the
+	// name of the node.
+	// This event does not pause the VM.
+	NodeStart(nodeName string) error
+
+	// PrepareForLines is called when the dialogue system anticipates that it
+	// will deliver some lines. Note that not every line prepared may end up
+	// being run.
+	// This event does not pause the VM.
+	PrepareForLines(lineIDs []string) error
+
+	// Line is called when the dialogue system runs a line of dialogue. This
+	// event pauses the VM until AsyncAdapter.Go is called.
+	Line(line Line)
+
+	// Options is called to deliver a set of options to the game. The player
+	// should choose one of the options.
+	// This event pauses the VM.
+	Options(options []Option)
+
+	// Command is called when the dialogue system runs a command.
+	Command(command string)
+
+	// NodeComplete is called when a node has completed execution. It is passed
+	// the name of the node.
+	NodeComplete(nodeName string) error
+
+	// DialogueComplete is called when the dialogue as a whole is complete.
+	DialogueComplete() error
+}

--- a/fake.go
+++ b/fake.go
@@ -54,3 +54,46 @@ func (FakeDialogueHandler) NodeComplete(string) error { return nil }
 
 // DialogueComplete returns nil.
 func (FakeDialogueHandler) DialogueComplete() error { return nil }
+
+// FakeAsyncDialogueHandler implements AsyncDialogueHandler with minimal,
+// do-nothing methods. This is useful both for testing, and for satisfying the
+// interface via embedding, e.g.:
+//
+//		   type MyHandler struct {
+//			      FakeAsyncDialogueHandler
+//		   }
+//		   // MyHandler is only interested in Line and Options.
+//		   func (m MyHandler) Line(line Line) { ... }
+//		   func (m MyHandler) Options(options []Option) { ... }
+//		   // All the other AsyncDialogueHandler methods provided by
+//	    // FakeAsyncDialogueHandler.
+type FakeAsyncDialogueHandler struct{}
+
+// NodeStart returns nil.
+func (FakeAsyncDialogueHandler) NodeStart(string) error {
+	return nil
+}
+
+// PrepareForLines returns nil.
+func (FakeAsyncDialogueHandler) PrepareForLines([]string) error {
+	return nil
+}
+
+// Line does nothing.
+func (FakeAsyncDialogueHandler) Line(Line) {}
+
+// Options does nothing.
+func (FakeAsyncDialogueHandler) Options([]Option) {}
+
+// Command does nothing.
+func (FakeAsyncDialogueHandler) Command(string) {}
+
+// NodeComplete returns nil.
+func (FakeAsyncDialogueHandler) NodeComplete(string) error {
+	return nil
+}
+
+// DialogueComplete returns nil.
+func (FakeAsyncDialogueHandler) DialogueComplete() error {
+	return nil
+}


### PR DESCRIPTION
`AsyncAdapter` can be used to handle events in an asynchronous manner, similar to the main Yarn Spinner implementation.`AsyncAdapter` is a `DialogueHandler` that can be passed to `VirtualMachine`. Then, the user can supply an `AsyncDialogueHandler`. Once any of the messages are called on the `AsyncDialogueHandler`, the VM execution is paused, and can continue by calling `Go` or `GoWithChoice` on `AsyncAdapter`, or can be stopped entirely with `Abort`.